### PR TITLE
Fixed styling on navbar allowing access to Logout button

### DIFF
--- a/www/public/stylesheets/main.css
+++ b/www/public/stylesheets/main.css
@@ -8,7 +8,6 @@ body .navbar-fixed-top {
   right: inherit;
   top: inherit;
   padding-left: 220px;
-  z-index: 0;
 }
 
 body .sidebar {


### PR DESCRIPTION
The z-index of the navbar was set incorrectly, allowing the content to be positioned over the nav dropdown. This prevented the user Logout button from functioning properly. 