### PR TITLE
add hack to make HTTP PATCH work in ruby

### DIFF
--- a/generator/app/models/RubyHttpClient.scala
+++ b/generator/app/models/RubyHttpClient.scala
@@ -109,6 +109,14 @@ require 'bigdecimal'
         do_request(Net::HTTP::Put, &block)
       end
 
+      class PATCH < Net::HTTP::Put
+        METHOD = "PATCH"
+      end
+
+      def patch(&block)
+        do_request(PATCH, &block)
+      end
+
       def do_request(klass)
         Preconditions.assert_class('klass', klass, Class)
 

--- a/generator/test/resources/ruby-client-generator-gilt-0.0.1-test.txt
+++ b/generator/test/resources/ruby-client-generator-gilt-0.0.1-test.txt
@@ -549,6 +549,14 @@ module ApidocReferenceApi
         do_request(Net::HTTP::Put, &block)
       end
 
+      class PATCH < Net::HTTP::Put
+        METHOD = "PATCH"
+      end
+
+      def patch(&block)
+        do_request(PATCH, &block)
+      end
+
       def do_request(klass)
         Preconditions.assert_class('klass', klass, Class)
 


### PR DESCRIPTION
Ruby 1.8.7 does not have Net::HTTP:PATCH,
so we need to define our own.

This should be compatible with newer versions of ruby
that DO define the class, because it is namespaced.