### PR TITLE
don't swallow error messages in the API

### DIFF
--- a/api/app/Global.scala
+++ b/api/app/Global.scala
@@ -22,12 +22,12 @@ object Global extends WithFilters(LoggingFilter) {
   }
 
   override def onBadRequest(request: RequestHeader, error: String) = {
-    Future.successful(BadRequest(Json.toJson(Validation.serverError("Bad Request"))))
+    Future.successful(BadRequest(Json.toJson(Validation.serverError(error))))
   }
 
   override def onError(request: RequestHeader, ex: Throwable) = {
     Logger.error(ex.toString, ex)
-    Future.successful(InternalServerError(Json.toJson(Validation.serverError())))
+    Future.successful(InternalServerError(Json.toJson(Validation.serverError(ex.getMessage))))
   }
 
   private def ensureServices() {


### PR DESCRIPTION
the existing onBadRequest and onServerError methods
make it impossible to debug basic things like a missing
Content-Type header