### PR TITLE
Import private services

### DIFF
--- a/api/app/actors/MainActor.scala
+++ b/api/app/actors/MainActor.scala
@@ -17,6 +17,11 @@ object MainActor {
     case class MembershipRequestAccepted(organizationGuid: UUID, userGuid: UUID, role: Role)
     case class MembershipRequestDeclined(organizationGuid: UUID, userGuid: UUID, role: Role)
     case class MembershipCreated(guid: UUID)
+
+    case class SegmentCreated(segment: Segment)
+    case class SegmentUpdated(segment: Segment)
+    case class SegmentDeleted(segment: Segment)
+
     case class PasswordResetRequestCreated(guid: UUID)
     case class ApplicationCreated(guid: UUID)
     case class UserCreated(guid: UUID)

--- a/api/app/actors/MainActor.scala
+++ b/api/app/actors/MainActor.scala
@@ -18,10 +18,6 @@ object MainActor {
     case class MembershipRequestDeclined(organizationGuid: UUID, userGuid: UUID, role: Role)
     case class MembershipCreated(guid: UUID)
 
-    case class SegmentCreated(segment: Segment)
-    case class SegmentUpdated(segment: Segment)
-    case class SegmentDeleted(segment: Segment)
-
     case class PasswordResetRequestCreated(guid: UUID)
     case class ApplicationCreated(guid: UUID)
     case class UserCreated(guid: UUID)

--- a/api/app/controllers/Applications.scala
+++ b/api/app/controllers/Applications.scala
@@ -18,7 +18,7 @@ object Applications extends Controller {
     offset: Long = 0
   ) = AnonymousRequest { request =>
     val applications = ApplicationsDao.findAll(
-      Authorization(request.user),
+      request.authorization,
       orgKey = Some(orgKey),
       name = name,
       key = key,

--- a/api/app/controllers/AuthenticatedRequest.scala
+++ b/api/app/controllers/AuthenticatedRequest.scala
@@ -21,24 +21,45 @@ private[controllers] case class UserAuth(
 )
 
 
+case class AuthHeaders(
+  authorization: Option[String],
+  userGuid: Option[String]
+) {
+
+  def toSeq(): Seq[(String, String)] = {
+    Seq(
+      authorization.map { v => (RequestHelper.AuthorizationHeader, v) },
+      userGuid.map { v => (RequestHelper.UserGuidHeader, v) }
+    ).flatten
+  }
+
+}
+
+object AuthHeaders {
+
+  def apply(headers: play.api.mvc.Headers): AuthHeaders = {
+    AuthHeaders(
+      authorization = headers.get(RequestHelper.AuthorizationHeader),
+      userGuid = headers.get(RequestHelper.UserGuidHeader)
+    )
+  }
+
+}
+
 private[controllers] object RequestHelper {
 
   val UserGuidHeader = "X-User-Guid"
   val AuthorizationHeader = "Authorization"
 
-  def userAuth(
-    authorizationHeader: Option[String],
-    userGuidHeader: Option[String]
-  ): UserAuth = {
-
-    val tokenUser: Option[User] = BasicAuthorization.get(authorizationHeader) match {
+  def userAuth(authHeaders: AuthHeaders): UserAuth = {
+    val tokenUser: Option[User] = BasicAuthorization.get(authHeaders.authorization) match {
       case Some(auth: BasicAuthorization.Token) => {
         UsersDao.findByToken(auth.token)
       }
       case _ => None
     }
 
-    userGuidHeader.flatMap(UsersDao.findByGuid(_)) match {
+    authHeaders.userGuid.flatMap(UsersDao.findByGuid(_)) match {
       case None => {
         /**
           * Currently a hack. If the token user is NOT our system user
@@ -67,18 +88,22 @@ private[controllers] object RequestHelper {
 
 }
 
-class AnonymousRequest[A](val tokenUser: Option[User], val user: Option[User], request: Request[A]) extends WrappedRequest[A](request)
+class AnonymousRequest[A](
+  val authHeaders: AuthHeaders,
+  val tokenUser: Option[User],
+  val user: Option[User],
+  request: Request[A]
+) extends WrappedRequest[A](request)
 
 object AnonymousRequest extends ActionBuilder[AnonymousRequest] {
 
   def invokeBlock[A](request: Request[A], block: (AnonymousRequest[A]) => Future[Result]) = {
-    val userAuth = RequestHelper.userAuth(
-      request.headers.get(RequestHelper.AuthorizationHeader),
-      request.headers.get(RequestHelper.UserGuidHeader)
-    )
+    val headers = AuthHeaders(request.headers)
+    val userAuth = RequestHelper.userAuth(headers)
 
     block(
       new AnonymousRequest(
+        authHeaders = headers,
         tokenUser = userAuth.tokenUser,
         user = userAuth.user,
         request = request
@@ -88,7 +113,12 @@ object AnonymousRequest extends ActionBuilder[AnonymousRequest] {
 
 }
 
-class AuthenticatedRequest[A](val tokenUser: User, val user: User, request: Request[A]) extends WrappedRequest[A](request) {
+class AuthenticatedRequest[A](
+  val authHeaders: AuthHeaders,
+  val tokenUser: User,
+  val user: User,
+  request: Request[A]
+) extends WrappedRequest[A](request) {
 
   def requireAdmin(org: Organization) {
     require(MembershipsDao.isUserAdmin(user, org), s"Action requires admin role. User[${user.guid}] is not an admin of Org[${org.key}]")
@@ -103,10 +133,8 @@ class AuthenticatedRequest[A](val tokenUser: User, val user: User, request: Requ
 object Authenticated extends ActionBuilder[AuthenticatedRequest] {
 
   def invokeBlock[A](request: Request[A], block: (AuthenticatedRequest[A]) => Future[Result]) = {
-    val userAuth = RequestHelper.userAuth(
-      request.headers.get(RequestHelper.AuthorizationHeader),
-      request.headers.get(RequestHelper.UserGuidHeader)
-    )
+    val headers = AuthHeaders(request.headers)
+    val userAuth = RequestHelper.userAuth(headers)
 
     userAuth.user match {
       case None => {
@@ -114,7 +142,12 @@ object Authenticated extends ActionBuilder[AuthenticatedRequest] {
       }
 
       case Some(user) => {
-        block(new AuthenticatedRequest(userAuth.tokenUser.get, user, request))
+        block(new AuthenticatedRequest(
+          authHeaders = headers,
+          userAuth.tokenUser.get,
+          user,
+          request)
+        )
       }
     }
   }

--- a/api/app/controllers/AuthenticatedRequest.scala
+++ b/api/app/controllers/AuthenticatedRequest.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import com.gilt.apidoc.api.v0.models.{Organization, User}
-import db.{MembershipsDao, UsersDao}
+import db.{Authorization, MembershipsDao, UsersDao}
 import play.api.mvc._
 import play.api.mvc.Results.Unauthorized
 import scala.concurrent.Future
@@ -93,7 +93,11 @@ class AnonymousRequest[A](
   val tokenUser: Option[User],
   val user: Option[User],
   request: Request[A]
-) extends WrappedRequest[A](request)
+) extends WrappedRequest[A](request) {
+
+  val authorization = Authorization(user.map(_.guid))
+
+}
 
 object AnonymousRequest extends ActionBuilder[AnonymousRequest] {
 
@@ -119,6 +123,8 @@ class AuthenticatedRequest[A](
   val user: User,
   request: Request[A]
 ) extends WrappedRequest[A](request) {
+
+  val authorization = Authorization.User(user.guid)
 
   def requireAdmin(org: Organization) {
     require(MembershipsDao.isUserAdmin(user, org), s"Action requires admin role. User[${user.guid}] is not an admin of Org[${org.key}]")

--- a/api/app/controllers/Code.scala
+++ b/api/app/controllers/Code.scala
@@ -31,13 +31,13 @@ object Code extends Controller {
     versionName: String,
     generatorKey: String
   ) = AnonymousRequest.async { request =>
-    VersionsDao.findVersion(Authorization(request.user), orgKey, applicationKey, versionName) match {
+    VersionsDao.findVersion(request.authorization, orgKey, applicationKey, versionName) match {
       case None => {
         Future.successful(NotFound)
       }
 
       case Some(version) => {
-        GeneratorsDao.findAll(Authorization(request.user), key = Some(generatorKey)).headOption match {
+        GeneratorsDao.findAll(request.authorization, key = Some(generatorKey)).headOption match {
           case None => {
             Future.successful(Conflict(Json.toJson(Validation.error(s"Generator with key[$generatorKey] not found"))))
           }

--- a/api/app/controllers/MembershipRequests.scala
+++ b/api/app/controllers/MembershipRequests.scala
@@ -31,7 +31,7 @@ object MembershipRequests extends Controller {
     offset: Long = 0
   ) = Authenticated { request =>
     val requests = MembershipRequestsDao.findAll(
-      Authorization(Some(request.user)),
+      request.authorization,
       organizationGuid = organizationGuid,
       organizationKey = organizationKey,
       userGuid = userGuid,
@@ -81,7 +81,7 @@ object MembershipRequests extends Controller {
   }
 
   def postAcceptByGuid(guid: UUID) = Authenticated { request =>
-    MembershipRequestsDao.findByGuid(Authorization(Some(request.user)), guid) match {
+    MembershipRequestsDao.findByGuid(request.authorization, guid) match {
       case None => NotFound
       case Some(mr) => {
         MembershipRequestsDao.accept(request.user, mr)
@@ -91,7 +91,7 @@ object MembershipRequests extends Controller {
   }
 
   def postDeclineByGuid(guid: UUID) = Authenticated { request =>
-    MembershipRequestsDao.findByGuid(Authorization(Some(request.user)), guid) match {
+    MembershipRequestsDao.findByGuid(request.authorization, guid) match {
       case None => NotFound
       case Some(mr) => {
         MembershipRequestsDao.decline(request.user, mr)

--- a/api/app/controllers/Memberships.scala
+++ b/api/app/controllers/Memberships.scala
@@ -20,7 +20,7 @@ object Memberships extends Controller {
     Ok(
       Json.toJson(
         MembershipsDao.findAll(
-          Authorization(Some(request.user)),
+          request.authorization,
           organizationGuid = organizationGuid,
           organizationKey = organizationKey,
           userGuid = userGuid,
@@ -33,7 +33,7 @@ object Memberships extends Controller {
   }
 
   def getByGuid(guid: UUID) = Authenticated { request =>
-    MembershipsDao.findByGuid(Authorization(Some(request.user)), guid) match {
+    MembershipsDao.findByGuid(request.authorization, guid) match {
       case None => NotFound
       case Some(membership) => {
         if (MembershipsDao.isUserAdmin(request.user, membership.organization)) {
@@ -46,7 +46,7 @@ object Memberships extends Controller {
   }
 
   def deleteByGuid(guid: UUID) = Authenticated { request =>
-    MembershipsDao.findByGuid(Authorization(Some(request.user)), guid) match {
+    MembershipsDao.findByGuid(request.authorization, guid) match {
       case None => NoContent
       case Some(membership) => {
         if (MembershipsDao.isUserAdmin(request.user, membership.organization)) {

--- a/api/app/controllers/Organizations.scala
+++ b/api/app/controllers/Organizations.scala
@@ -22,7 +22,7 @@ object Organizations extends Controller {
     Ok(
       Json.toJson(
         OrganizationsDao.findAll(
-          Authorization(request.user),
+          request.authorization,
           userGuid = userGuid,
           guid = guid,
           key = key,
@@ -36,7 +36,7 @@ object Organizations extends Controller {
   }
 
   def getByKey(key: String) = AnonymousRequest { request =>
-    OrganizationsDao.findByKey(Authorization(request.user), key) match {
+    OrganizationsDao.findByKey(request.authorization, key) match {
       case None => NotFound
       case Some(org) => Ok(Json.toJson(org))
     }
@@ -66,7 +66,7 @@ object Organizations extends Controller {
         Conflict(Json.toJson(Validation.invalidJson(e)))
       }
       case s: JsSuccess[OrganizationForm] => { 
-        OrganizationsDao.findByKey(Authorization(Some(request.user)), key) match {
+        OrganizationsDao.findByKey(request.authorization, key) match {
           case None => NotFound
           case Some(existing) => {
             val form = s.get

--- a/api/app/controllers/Subscriptions.scala
+++ b/api/app/controllers/Subscriptions.scala
@@ -22,7 +22,7 @@ trait Subscriptions {
     offset: Long = 0
   ) = Authenticated { request =>
     val subscriptions = SubscriptionsDao.findAll(
-      Authorization(Some(request.user)),
+      request.authorization,
       guid = guid,
       organizationKey = organizationKey,
       userGuid = userGuid,

--- a/api/app/controllers/Tokens.scala
+++ b/api/app/controllers/Tokens.scala
@@ -20,7 +20,7 @@ trait Tokens {
     offset: Long = 0
   ) = Authenticated { request =>
     val tokens = TokensDao.findAll(
-      Authorization(Some(request.user)),
+      request.authorization,
       userGuid = Some(userGuid),
       guid = guid,
       limit = limit,
@@ -32,7 +32,7 @@ trait Tokens {
   def getCleartextByGuid(
     guid: UUID
   ) = Authenticated { request =>
-    TokensDao.findCleartextByGuid(Authorization(Some(request.user)), guid) match {
+    TokensDao.findCleartextByGuid(request.authorization, guid) match {
       case None => NotFound
       case Some(token) => {
         Ok(Json.toJson(token))
@@ -61,7 +61,7 @@ trait Tokens {
   }
 
   def deleteByGuid(guid: UUID) = Authenticated { request =>
-    TokensDao.findByGuid(Authorization(Some(request.user)), guid).map { token =>
+    TokensDao.findByGuid(request.authorization, guid).map { token =>
       TokensDao.softDelete(request.user, token)
     }
     NoContent

--- a/api/app/controllers/Validations.scala
+++ b/api/app/controllers/Validations.scala
@@ -27,7 +27,7 @@ object Validations extends Controller {
         OriginalValidator(
           config = config,
           original = Original(fileType, contents),
-          fetcher = DatabaseServiceFetcher()
+          fetcher = DatabaseServiceFetcher(request.authorization)
         ).validate match {
           case Left(errors) => {
             BadRequest(Json.toJson(Validation(false, errors)))

--- a/api/app/controllers/Versions.scala
+++ b/api/app/controllers/Versions.scala
@@ -4,6 +4,7 @@ import com.gilt.apidoc.api.v0.models.{Application, ApplicationForm, Organization
 import com.gilt.apidoc.api.v0.models.json._
 import com.gilt.apidoc.spec.v0.models.Service
 import lib.ServiceConfiguration
+import core.ClientFetcher
 import builder.OriginalValidator
 import lib.{OriginalUtil, Validation}
 import db.{ApplicationsDao, Authorization, OrganizationsDao, VersionValidator, VersionsDao}
@@ -50,7 +51,11 @@ object Versions extends Controller {
               }
               case s: JsSuccess[VersionForm] => {
                 val form = s.get
-                OriginalValidator(toServiceConfiguration(org, versionName), OriginalUtil.toOriginal(form.originalForm)).validate match {
+                OriginalValidator(
+                  config = toServiceConfiguration(org, versionName),
+                  original = OriginalUtil.toOriginal(form.originalForm),
+                  fetcher = ClientFetcher(requestHeaders = request.authHeaders.toSeq)
+                ).validate match {
                   case Left(errors) => {
                     Conflict(Json.toJson(Validation.errors(errors)))
                   }
@@ -98,7 +103,11 @@ object Versions extends Controller {
               }
               case s: JsSuccess[VersionForm] => {
                 val form = s.get
-                OriginalValidator(toServiceConfiguration(org, versionName), OriginalUtil.toOriginal(form.originalForm)).validate match {
+                OriginalValidator(
+                  config = toServiceConfiguration(org, versionName),
+                  original = OriginalUtil.toOriginal(form.originalForm),
+                  fetcher = ClientFetcher(requestHeaders = request.authHeaders.toSeq)
+                ).validate match {
                   case Left(errors) => {
                     Conflict(Json.toJson(Validation.errors(errors)))
                   }

--- a/api/app/controllers/Versions.scala
+++ b/api/app/controllers/Versions.scala
@@ -4,9 +4,8 @@ import com.gilt.apidoc.api.v0.models.{Application, ApplicationForm, Organization
 import com.gilt.apidoc.api.v0.models.json._
 import com.gilt.apidoc.spec.v0.models.Service
 import lib.ServiceConfiguration
-import core.ClientFetcher
 import builder.OriginalValidator
-import lib.{OriginalUtil, Validation}
+import lib.{DatabaseServiceFetcher, OriginalUtil, Validation}
 import db.{ApplicationsDao, Authorization, OrganizationsDao, VersionValidator, VersionsDao}
 import play.api.mvc._
 import play.api.libs.json._
@@ -54,7 +53,7 @@ object Versions extends Controller {
                 OriginalValidator(
                   config = toServiceConfiguration(org, versionName),
                   original = OriginalUtil.toOriginal(form.originalForm),
-                  fetcher = ClientFetcher(requestHeaders = request.authHeaders.toSeq)
+                  fetcher = DatabaseServiceFetcher()
                 ).validate match {
                   case Left(errors) => {
                     Conflict(Json.toJson(Validation.errors(errors)))
@@ -106,7 +105,7 @@ object Versions extends Controller {
                 OriginalValidator(
                   config = toServiceConfiguration(org, versionName),
                   original = OriginalUtil.toOriginal(form.originalForm),
-                  fetcher = ClientFetcher(requestHeaders = request.authHeaders.toSeq)
+                  fetcher = DatabaseServiceFetcher()
                 ).validate match {
                   case Left(errors) => {
                     Conflict(Json.toJson(Validation.errors(errors)))

--- a/api/app/controllers/Watches.scala
+++ b/api/app/controllers/Watches.scala
@@ -22,7 +22,7 @@ trait Watches {
     offset: Long = 0
   ) = Authenticated { request =>
     val watches = WatchesDao.findAll(
-      Authorization(Some(request.user)),
+      request.authorization,
       guid = guid,
       userGuid = userGuid,
       organizationKey =  organizationKey,
@@ -46,7 +46,7 @@ trait Watches {
     applicationKey: String
   ) = Authenticated { request =>
     WatchesDao.findAll(
-      Authorization(Some(request.user)),
+      request.authorization,
       userGuid = userGuid,
       organizationKey =  Some(organizationKey),
       applicationKey = Some(applicationKey),

--- a/api/app/db/Authorization.scala
+++ b/api/app/db/Authorization.scala
@@ -148,10 +148,10 @@ object Authorization {
 
   }
 
-  def apply(user: Option[com.gilt.apidoc.api.v0.models.User]): Authorization = {
-    user match {
+  def apply(userGuid: Option[UUID]): Authorization = {
+    userGuid match {
       case None => PublicOnly
-      case Some(u) => User(u.guid)
+      case Some(guid) => User(guid)
     }
   }
 

--- a/api/app/db/SubscriptionsDao.scala
+++ b/api/app/db/SubscriptionsDao.scala
@@ -41,7 +41,7 @@ object SubscriptionsDao {
     user: User,
     form: SubscriptionForm
   ): Seq[Error] = {
-    val org = OrganizationsDao.findByKey(Authorization(Some(user)), form.organizationKey)
+    val org = OrganizationsDao.findByKey(Authorization.User(user.guid), form.organizationKey)
 
     val organizationKeyErrors = org match {
         case None => Seq("Organization not found")
@@ -81,7 +81,7 @@ object SubscriptionsDao {
     val errors = validate(createdBy, form)
     assert(errors.isEmpty, errors.map(_.message).mkString("\n"))
 
-    val org = OrganizationsDao.findByKey(Authorization(Some(createdBy)), form.organizationKey).getOrElse {
+    val org = OrganizationsDao.findByKey(Authorization.User(createdBy.guid), form.organizationKey).getOrElse {
       sys.error("Failed to validate org for subscription")
     }
 
@@ -124,7 +124,7 @@ object SubscriptionsDao {
   }
 
   def findByUserAndGuid(user: User, guid: UUID): Option[Subscription] = {
-    findAll(Authorization(Some(user)), guid = Some(guid), limit = 1).headOption
+    findAll(Authorization.User(user.guid), guid = Some(guid), limit = 1).headOption
   }
 
   def findAll(

--- a/api/app/db/VersionsDao.scala
+++ b/api/app/db/VersionsDao.scala
@@ -1,7 +1,7 @@
 package db
 
-import lib.ServiceConfiguration
-import core.{ClientFetcher, VersionMigration}
+import lib.{DatabaseServiceFetcher, ServiceConfiguration}
+import core.VersionMigration
 import builder.OriginalValidator
 import com.gilt.apidoc.api.v0.models.{Application, Original, OriginalType, Reference, User, Version, VersionForm, Visibility}
 import com.gilt.apidoc.spec.v0.models.Service
@@ -220,7 +220,7 @@ object VersionsDao {
           val validator = OriginalValidator(
             config = config,
             original = original,
-            fetcher = ClientFetcher(requestHeaders = Nil), // TODO
+            fetcher = DatabaseServiceFetcher(),
             migration = VersionMigration(internal = true)
           )
           validator.validate match {

--- a/api/app/db/VersionsDao.scala
+++ b/api/app/db/VersionsDao.scala
@@ -220,7 +220,7 @@ object VersionsDao {
           val validator = OriginalValidator(
             config = config,
             original = original,
-            fetcher = DatabaseServiceFetcher(),
+            fetcher = DatabaseServiceFetcher(Authorization.All),
             migration = VersionMigration(internal = true)
           )
           validator.validate match {

--- a/api/app/db/VersionsDao.scala
+++ b/api/app/db/VersionsDao.scala
@@ -1,7 +1,7 @@
 package db
 
 import lib.ServiceConfiguration
-import core.VersionMigration
+import core.{ClientFetcher, VersionMigration}
 import builder.OriginalValidator
 import com.gilt.apidoc.api.v0.models.{Application, Original, OriginalType, Reference, User, Version, VersionForm, Visibility}
 import com.gilt.apidoc.spec.v0.models.Service
@@ -217,7 +217,12 @@ object VersionsDao {
         )
 
         try {
-          val validator = OriginalValidator(config, original, migration = VersionMigration(internal = true))
+          val validator = OriginalValidator(
+            config = config,
+            original = original,
+            fetcher = ClientFetcher(requestHeaders = Nil), // TODO
+            migration = VersionMigration(internal = true)
+          )
           validator.validate match {
             case Left(errors) => {
             Logger.error(s"Error migrating $orgKey/$applicationKey/$versionName guid[$versionGuid] - invalid JSON: " + errors.distinct.mkString(", "))

--- a/api/app/db/WatchesDao.scala
+++ b/api/app/db/WatchesDao.scala
@@ -15,7 +15,8 @@ case class FullWatchForm(
   form: WatchForm
 ) {
 
-  private val auth = Authorization(Some(createdBy))
+  private val auth = Authorization.User(createdBy.guid)
+
   val org: Option[Organization] = OrganizationsDao.findByKey(auth, form.organizationKey)
   val application: Option[Application] = org.flatMap { o =>
     ApplicationsDao.findByOrganizationKeyAndApplicationKey(auth, o.key, form.applicationKey)
@@ -121,7 +122,7 @@ object WatchesDao {
   }
 
   def findByUserAndGuid(user: User, guid: UUID): Option[Watch] = {
-    findByGuid(Authorization(Some(user)), guid)
+    findByGuid(Authorization.User(user.guid), guid)
   }
 
   def findAll(

--- a/api/app/lib/DatabaseServiceFetcher.scala
+++ b/api/app/lib/DatabaseServiceFetcher.scala
@@ -3,11 +3,12 @@ package lib
 import core.ServiceFetcher
 import com.gilt.apidoc.spec.v0.models.Service
 import db.{ApplicationsDao, Authorization, VersionsDao}
+import java.util.UUID
 
 /**
   * Implements service fetch by querying the DB
   */
-case class DatabaseServiceFetcher() extends ServiceFetcher {
+case class DatabaseServiceFetcher(authorization: Authorization) extends ServiceFetcher {
 
   override def fetch(uri: String): Service = {
     println(s"fetch uri[$uri]")
@@ -18,7 +19,7 @@ case class DatabaseServiceFetcher() extends ServiceFetcher {
       }
 
       case Some(serviceUri) => {
-        VersionsDao.findVersion(Authorization.All, serviceUri.org, serviceUri.app, serviceUri.version).headOption.map(_.service).getOrElse {
+        VersionsDao.findVersion(authorization, serviceUri.org, serviceUri.app, serviceUri.version).headOption.map(_.service).getOrElse {
           sys.error(s"Error while fetching service for URI[$uri] - could not find [${serviceUri.org}/${serviceUri.app}:${serviceUri.version}]")
         }
       }

--- a/api/app/lib/DatabaseServiceFetcher.scala
+++ b/api/app/lib/DatabaseServiceFetcher.scala
@@ -1,0 +1,28 @@
+package lib
+
+import core.ServiceFetcher
+import com.gilt.apidoc.spec.v0.models.Service
+import db.{ApplicationsDao, Authorization, VersionsDao}
+
+/**
+  * Implements service fetch by querying the DB
+  */
+case class DatabaseServiceFetcher() extends ServiceFetcher {
+
+  override def fetch(uri: String): Service = {
+    println(s"fetch uri[$uri]")
+    ServiceUri.parse(uri) match {
+
+      case None => {
+        sys.error(s"could not parse URI[$uri]")
+      }
+
+      case Some(serviceUri) => {
+        VersionsDao.findVersion(Authorization.All, serviceUri.org, serviceUri.app, serviceUri.version).headOption.map(_.service).getOrElse {
+          sys.error(s"Error while fetching service for URI[$uri] - could not find [${serviceUri.org}/${serviceUri.app}:${serviceUri.version}]")
+        }
+      }
+    }
+  }
+
+}

--- a/api/app/lib/ServiceUri.scala
+++ b/api/app/lib/ServiceUri.scala
@@ -1,0 +1,36 @@
+package lib
+
+case class ServiceUri(
+  host: String,
+  org: String,
+  app: String,
+  version: String
+)
+
+/**
+  * Parses the URI for a service.json file into its component parts
+  */
+object ServiceUri {
+
+  private val Pattern = """^https?:\/\/([^\/]+)/([^\/]+)/([^\/]+)/([^\/]+)\/service.json$""".r
+
+  def parse(uri: String): Option[ServiceUri] = {
+    uri.toLowerCase.trim match {
+      case Pattern(host, org, app, version) => {
+        Some(
+          ServiceUri(
+            host = host,
+            org = org,
+            app = app,
+            version = version
+          )
+        )
+      }
+
+      case _ => {
+        None
+      }
+    }
+  }
+
+}

--- a/api/test/db/VersionsDaoSpec.scala
+++ b/api/test/db/VersionsDaoSpec.scala
@@ -1,6 +1,6 @@
 package db
 
-import lib.ServiceConfiguration
+import lib.{DatabaseServiceFetcher, ServiceConfiguration}
 import builder.OriginalValidator
 import com.gilt.apidoc.api.v0.models.{ApplicationForm, OriginalType, Version, Visibility}
 import com.gilt.apidoc.spec.v0.models.{Application, Organization, Service}
@@ -83,9 +83,13 @@ class VersionsDaoSpec extends FunSpec with Matchers {
       version = "0.0.2"
     )
 
-    val validator = OriginalValidator(serviceConfig, version.original.getOrElse {
-      sys.error("Missing original")
-    })
+    val validator = OriginalValidator(
+      config = serviceConfig,
+      original = version.original.getOrElse {
+        sys.error("Missing original")
+      },
+      fetcher = DatabaseServiceFetcher()
+    )
     validator.validate match {
       case Left(errors) => fail(errors.mkString("\n"))
       case Right(_) => {}

--- a/api/test/db/VersionsDaoSpec.scala
+++ b/api/test/db/VersionsDaoSpec.scala
@@ -88,7 +88,7 @@ class VersionsDaoSpec extends FunSpec with Matchers {
       original = version.original.getOrElse {
         sys.error("Missing original")
       },
-      fetcher = DatabaseServiceFetcher()
+      fetcher = DatabaseServiceFetcher(Authorization.All)
     )
     validator.validate match {
       case Left(errors) => fail(errors.mkString("\n"))

--- a/api/test/lib/ServiceUriSpec.scala
+++ b/api/test/lib/ServiceUriSpec.scala
@@ -1,0 +1,42 @@
+package lib
+
+import org.scalatest.{FunSpec, ShouldMatchers}
+
+class ServiceUriSpec extends FunSpec with ShouldMatchers {
+
+  describe("parse") {
+
+    it("invalid URIs") {
+      ServiceUri.parse("") should be(None)
+      ServiceUri.parse("foo") should be(None)
+      ServiceUri.parse("http://foo") should be(None)
+      ServiceUri.parse("http://foo:9000/123") should be(None)
+      ServiceUri.parse("http://localhost:9000/gilt/apidoc/latest/service") should be(None)
+    }
+
+    it("valid URIs") {
+      ServiceUri.parse("http://localhost:9000/gilt/apidoc/latest/service.json") should be(Some(ServiceUri(
+        host = "localhost:9000",
+        org = "gilt",
+        app = "apidoc",
+        version = "latest"
+      )))
+
+      ServiceUri.parse("http://localhost:9000/gilt/apidoc/0.9.1-dev/service.json") should be(Some(ServiceUri(
+        host = "localhost:9000",
+        org = "gilt",
+        app = "apidoc",
+        version = "0.9.1-dev"
+      )))
+
+      ServiceUri.parse(" HTTPS://localhost:9000/gilt/apidoc/0.9.1-dev/service.json") should be(Some(ServiceUri(
+        host = "localhost:9000",
+        org = "gilt",
+        app = "apidoc",
+        version = "0.9.1-dev"
+      )))
+    }
+
+  }
+
+}

--- a/core/src/main/scala/core/ServiceFetcher.scala
+++ b/core/src/main/scala/core/ServiceFetcher.scala
@@ -14,7 +14,10 @@ trait ServiceFetcher {
 
 }
 
-case class ClientFetcher() extends ServiceFetcher {
+case class ClientFetcher(
+  requestHeaders: Seq[(String, String)]
+) extends ServiceFetcher {
+  assert(!requestHeaders.isEmpty)
 
   override def fetch(uri: String): Service = {
     if (uri.trim.toLowerCase.startsWith("file://")) {
@@ -30,6 +33,11 @@ case class ClientFetcher() extends ServiceFetcher {
   }
 
   private def fetchContentsFromUri(uri: String): Service = {
+    println("FETCHING URI: " + uri)
+    requestHeaders.foreach { h =>
+      println(s" - header[$h]")
+    }
+
     import scala.concurrent.ExecutionContext.Implicits.global
     import scala.concurrent.Await
     import scala.concurrent.duration._

--- a/core/src/main/scala/core/ServiceFetcher.scala
+++ b/core/src/main/scala/core/ServiceFetcher.scala
@@ -42,7 +42,10 @@ case class ClientFetcher(
     import scala.concurrent.Await
     import scala.concurrent.duration._
 
-    val client = new com.gilt.apidoc.api.v0.Client(uri)
+    val client = new com.gilt.apidoc.api.v0.Client(
+      apiUrl = uri,
+      defaultHeaders = requestHeaders
+    )
 
     Await.result(
       client._executeRequest(Method.Get.toString, "").map {

--- a/core/src/main/scala/core/ServiceFetcher.scala
+++ b/core/src/main/scala/core/ServiceFetcher.scala
@@ -1,69 +1,9 @@
 package core
 
-import com.gilt.apidoc.api.v0.errors.FailedRequest
-import com.gilt.apidoc.spec.v0.models.{Method, Service}
-import com.gilt.apidoc.spec.v0.models.json._
-import play.api.libs.json.Json
-import java.net.URI
-import com.fasterxml.jackson.core.{JsonParseException, JsonProcessingException}
-import scala.util.{Failure, Success, Try}
+import com.gilt.apidoc.spec.v0.models.Service
 
 trait ServiceFetcher {
 
   def fetch(uri: String): Service
 
-}
-
-case class ClientFetcher(
-  requestHeaders: Seq[(String, String)]
-) extends ServiceFetcher {
-  assert(!requestHeaders.isEmpty)
-
-  override def fetch(uri: String): Service = {
-    if (uri.trim.toLowerCase.startsWith("file://")) {
-      fetchContentsFromFile(uri)
-    } else {
-      fetchContentsFromUri(uri)
-    }
-  }
-
-  private def fetchContentsFromFile(uri: String): Service = {
-    val contents = scala.io.Source.fromURI(new URI(uri)).getLines.mkString
-    Json.parse(contents).as[Service]
-  }
-
-  private def fetchContentsFromUri(uri: String): Service = {
-    println("FETCHING URI: " + uri)
-    requestHeaders.foreach { h =>
-      println(s" - header[$h]")
-    }
-
-    import scala.concurrent.ExecutionContext.Implicits.global
-    import scala.concurrent.Await
-    import scala.concurrent.duration._
-
-    val client = new com.gilt.apidoc.api.v0.Client(
-      apiUrl = uri,
-      defaultHeaders = requestHeaders
-    )
-
-    Await.result(
-      client._executeRequest(Method.Get.toString, "").map {
-        case r if r.status == 200 => {
-          try {
-            r.json.as[Service]
-          } catch {
-            case e: JsonParseException => {
-              throw new FailedRequest(r.status, s"Import Uri[$uri] did not return valid JSON")
-            }
-            case e: JsonProcessingException => {
-              throw new FailedRequest(r.status, s"Import Uri[$uri] did not return valid JSON")
-            }
-          }
-        }
-        case r => throw new FailedRequest(r.status, s"Expected HTTP 200 but received HTTP ${r.status}")
-      },
-      1000.millis
-    )
-  }
 }

--- a/core/src/main/scala/core/builder/OriginalValidator.scala
+++ b/core/src/main/scala/core/builder/OriginalValidator.scala
@@ -4,7 +4,7 @@ import me.apidoc.swagger.SwaggerServiceValidator
 import me.apidoc.avro.AvroIdlServiceValidator
 import api_json.ApiJsonServiceValidator
 import lib.{ServiceConfiguration, ServiceValidator}
-import core.{ClientFetcher, ServiceFetcher, VersionMigration}
+import core.{ServiceFetcher, VersionMigration}
 import com.gilt.apidoc.api.v0.models.{Original, OriginalType}
 import com.gilt.apidoc.spec.v0.models.Service
 
@@ -15,7 +15,7 @@ object OriginalValidator {
   def apply(
     config: ServiceConfiguration,
     original: Original,
-    fetcher: ServiceFetcher = new ClientFetcher(),
+    fetcher: ServiceFetcher,
     migration: VersionMigration = VersionMigration(internal = false)
   ): ServiceValidator[Service] = {
     val validator = original.`type` match {

--- a/core/src/main/scala/core/builder/api_json/ApiJsonServiceValidator.scala
+++ b/core/src/main/scala/core/builder/api_json/ApiJsonServiceValidator.scala
@@ -1,7 +1,7 @@
 package builder.api_json
 
 import builder.JsonUtil
-import core.{ClientFetcher, Importer, ServiceFetcher, Util, VersionMigration}
+import core.{Importer, ServiceFetcher, Util, VersionMigration}
 import lib.{ServiceConfiguration, ServiceValidator, UrlKey, VersionTag}
 import com.gilt.apidoc.spec.v0.models.Service
 import play.api.libs.json.{Json, JsObject}
@@ -11,7 +11,7 @@ import scala.util.{Failure, Success, Try}
 case class ApiJsonServiceValidator(
   config: ServiceConfiguration,
   apiJson: String,
-  fetcher: ServiceFetcher = new ClientFetcher(),
+  fetcher: ServiceFetcher,
   migration: VersionMigration
 ) extends ServiceValidator[Service] {
 

--- a/core/src/main/scala/core/builder/api_json/ServiceBuilder.scala
+++ b/core/src/main/scala/core/builder/api_json/ServiceBuilder.scala
@@ -1,6 +1,6 @@
 package builder.api_json
 
-import core.{ClientFetcher, Importer, ServiceFetcher, VersionMigration}
+import core.{Importer, ServiceFetcher, VersionMigration}
 import lib.{Datatype, Methods, Primitives, ServiceConfiguration, Text, Type, Kind, UrlKey}
 import com.gilt.apidoc.spec.v0.models._
 import play.api.libs.json._
@@ -17,7 +17,7 @@ case class ServiceBuilder(
   def apply(
     config: ServiceConfiguration,
     apiJson: String,
-    fetcher: ServiceFetcher = ClientFetcher()
+    fetcher: ServiceFetcher
   ): Service = {
     val jsValue = Json.parse(apiJson)
     apply(config, InternalServiceForm(jsValue, fetcher))

--- a/core/src/test/scala/core/FileServiceFetcher.scala
+++ b/core/src/test/scala/core/FileServiceFetcher.scala
@@ -1,0 +1,15 @@
+package core
+
+import com.gilt.apidoc.spec.v0.models.Service
+import com.gilt.apidoc.spec.v0.models.json._
+import play.api.libs.json.Json
+import java.net.URI
+
+case class FileServiceFetcher() extends ServiceFetcher {
+
+  override def fetch(uri: String): Service = {
+    val contents = scala.io.Source.fromURI(new URI(uri)).getLines.mkString
+    Json.parse(contents).as[Service]
+  }
+
+}

--- a/core/src/test/scala/core/ImportServiceSpec.scala
+++ b/core/src/test/scala/core/ImportServiceSpec.scala
@@ -111,7 +111,7 @@ class ImportServiceSpec extends FunSpec with Matchers {
       val validator = OriginalValidator(
         config = TestHelper.serviceConfig,
         original = Original(OriginalType.ApiJson, json2),
-        fetcher = ClientFetcher(requestHeaders = Nil)
+        fetcher = FileServiceFetcher()
       )
       validator.validate match {
         case Left(errors) => {

--- a/core/src/test/scala/core/ImportServiceSpec.scala
+++ b/core/src/test/scala/core/ImportServiceSpec.scala
@@ -108,7 +108,11 @@ class ImportServiceSpec extends FunSpec with Matchers {
   """
 
     it("parses service definition with imports") {
-      val validator = OriginalValidator(TestHelper.serviceConfig, Original(OriginalType.ApiJson, json2))
+      val validator = OriginalValidator(
+        config = TestHelper.serviceConfig,
+        original = Original(OriginalType.ApiJson, json2),
+        fetcher = ClientFetcher(requestHeaders = Nil)
+      )
       validator.validate match {
         case Left(errors) => {
           fail(errors.mkString(""))

--- a/core/src/test/scala/core/ImporterSpec.scala
+++ b/core/src/test/scala/core/ImporterSpec.scala
@@ -14,7 +14,7 @@ class ImporterSpec extends FunSpec with Matchers {
     """
 
     val path = TestHelper.writeToTempFile(json)
-    val imp = Importer(ClientFetcher(requestHeaders = Nil), s"file://$path")
+    val imp = Importer(FileServiceFetcher(), s"file://$path")
     imp.validate.size should be > 0
   }
 
@@ -49,7 +49,7 @@ class ImporterSpec extends FunSpec with Matchers {
 
     it("parses service") {
       val path = TestHelper.writeToTempFile(json)
-      val imp = Importer(ClientFetcher(requestHeaders = Nil), s"file://$path")
+      val imp = Importer(FileServiceFetcher(), s"file://$path")
       imp.validate should be(Seq.empty)
 
       val service = imp.service

--- a/core/src/test/scala/core/ImporterSpec.scala
+++ b/core/src/test/scala/core/ImporterSpec.scala
@@ -14,7 +14,7 @@ class ImporterSpec extends FunSpec with Matchers {
     """
 
     val path = TestHelper.writeToTempFile(json)
-    val imp = Importer(ClientFetcher(), s"file://$path")
+    val imp = Importer(ClientFetcher(requestHeaders = Nil), s"file://$path")
     imp.validate.size should be > 0
   }
 
@@ -49,7 +49,7 @@ class ImporterSpec extends FunSpec with Matchers {
 
     it("parses service") {
       val path = TestHelper.writeToTempFile(json)
-      val imp = Importer(ClientFetcher(), s"file://$path")
+      val imp = Importer(ClientFetcher(requestHeaders = Nil), s"file://$path")
       imp.validate should be(Seq.empty)
 
       val service = imp.service

--- a/generated/app/ApidocApi.scala
+++ b/generated/app/ApidocApi.scala
@@ -1133,7 +1133,8 @@ package com.gilt.apidoc.api.v0 {
 
   class Client(
     apiUrl: String,
-    auth: scala.Option[com.gilt.apidoc.api.v0.Authorization] = None
+    auth: scala.Option[com.gilt.apidoc.api.v0.Authorization] = None,
+    defaultHeaders: Seq[(String, String)] = Nil
   ) {
     import com.gilt.apidoc.api.v0.models.json._
 
@@ -1930,7 +1931,8 @@ package com.gilt.apidoc.api.v0 {
         "User-Agent" -> Constants.UserAgent,
         "X-Apidoc-Version" -> Constants.Version,
         "X-Apidoc-Version-Major" -> Constants.VersionMajor.toString
-      )
+      ).withHeaders(defaultHeaders : _*)
+
       auth.fold(holder) { a =>
         a match {
           case Authorization.Basic(username, password) => {

--- a/www/app/controllers/Generators.scala
+++ b/www/app/controllers/Generators.scala
@@ -49,7 +49,6 @@ object Generators extends Controller {
     boundForm.fold (
 
       errors => Future {
-        println("ERRORS: " + errors)
         InternalServerError
       },
 


### PR DESCRIPTION
 - Re-implement how imports work - now fetch imported services directly
   from the db by parsing the URL for the service to identify the org/app/version
 - Add authorization so that private services that the user has access to can also
   be imported. Previously only public services were supported.