### PR TITLE
Fix bug that prevented error reporting to user

### DIFF
--- a/api/test/lib/OriginalUtilSpec.scala
+++ b/api/test/lib/OriginalUtilSpec.scala
@@ -35,8 +35,12 @@ class OriginalUtilSpec extends FunSpec with ShouldMatchers {
       OriginalUtil.guessType("  protocol bar {}  ") should be(Some(OriginalType.AvroIdl))
     }
 
-    describe("unknown") {
+    it("unknown") {
       OriginalUtil.guessType("   ") should be(None)
+    }
+
+    it("poorly formatted json") {
+      OriginalUtil.guessType("{   ") should be(None)
     }
 
   }

--- a/script/upload
+++ b/script/upload
@@ -53,24 +53,6 @@ def print_error(msg)
   puts ""
 end
 
-# replace www.apidoc.me with localhost:9000 - useful when operating
-# locally in development mode
-def rewrite_host(path, from, to)
-  if !File.exists?(path)
-    print_error("Cannot find file[#{path}]")
-    exit(1)
-  end
-
-  tmp = "/tmp/apidoc.script.upload.#{Process.pid}.tmp"
-  File.open(tmp, "w") do |out|
-    IO.readlines(path).each do |l|
-      out << l.gsub(/#{from}/, to)
-    end
-  end
-
-  tmp
-end
-
 def cli(command, opts={})
   profile = opts.delete(:profile)
   if !opts.empty?
@@ -89,9 +71,7 @@ end
 
 def upload(profile, host, version, application, path)
   dir = File.dirname(__FILE__)
-  tmp = rewrite_host(File.join(dir, path), PRODUCTION_HOST, host)
-  cli("upload gilt #{application} #{tmp} --version #{version}", :profile => profile)
-  File.delete(tmp)
+  cli("upload gilt #{application} #{File.join(dir, path)} --version #{version}", :profile => profile)
 end
 
 upload(profile, host, version, "apidoc-spec", "../spec/service.json")

--- a/www/app/views/doc/apiJson.scala.html
+++ b/www/app/views/doc/apiJson.scala.html
@@ -406,19 +406,12 @@
 
     <ul>
 
-      <li> HTTP Response codes of 404, 5xx cannot be explicitly
-      specified and are handled automatically to ensure consistent
-      behavior in generated client libraries.</li>
+      <li> HTTP Response codes of 5xx cannot be explicitly specified
+      and are handled automatically to ensure consistent behavior in
+      generated client libraries.</li>
 
-      <ul>
-
-        <li> 404 response is automatically added for all GET requests</li>
-        <li> if a successful response returns an array, 404 returns an empty list</li>
-        <li> if a successful response returns a single instance, 404 returns null (or None in languages that support options)</li>
-
-      </ul>
-
-      <li> HTTP Response codes of 204 and 304 indicate that no content is returned, so they must use a type of <em>unit</em>.</li>
+      <li> HTTP Response codes of 204 and 304 indicate that no content
+      is returned, so they must use a type of <em>unit</em>.</li>
 
     </ul>
 


### PR DESCRIPTION
 - Fixes #326
 - Invalid json was not being checked by original util
   which propagated up as a 500
 - Catch parse errors here so we can report the error of
   invalid JSON to the user