### PR TITLE
Fix bug with case sensitive primitive type names

### DIFF
--- a/core/src/main/scala/core/builder/api_json/InternalServiceForm.scala
+++ b/core/src/main/scala/core/builder/api_json/InternalServiceForm.scala
@@ -672,10 +672,21 @@ private[api_json] object InternalDatatype {
 
   def apply(value: String): InternalDatatype = {
     value match {
-      case ListRx(name) => InternalDatatype.List(name, true)
-      case MapRx(name) => InternalDatatype.Map(name, true)
+      case ListRx(name) => InternalDatatype.List(formatName(name), true)
+      case MapRx(name) => InternalDatatype.Map(formatName(name), true)
       case DefaultMapRx() => InternalDatatype.Map(Primitives.String.toString, true)
-      case _ => InternalDatatype.Singleton(value, true)
+      case _ => InternalDatatype.Singleton(formatName(value), true)
+    }
+  }
+
+  /**
+    * Make primitive datatype names case insensitive to user
+    * input. e.g. accept both 'UUID' and 'uuid' as the uuid type.
+    */
+  private def formatName(name: String): String = {
+    Primitives(name) match {
+      case None => name
+      case Some(p) => p.toString
     }
   }
 

--- a/core/src/main/scala/core/builder/api_json/InternalServiceForm.scala
+++ b/core/src/main/scala/core/builder/api_json/InternalServiceForm.scala
@@ -700,18 +700,18 @@ private[api_json] object InternalDatatype {
         case Some(true) => {
           // User explicitly marked this required
           dt match {
-            case InternalDatatype.List(name, _) => InternalDatatype.List(name, true)
-            case InternalDatatype.Map(name, _) => InternalDatatype.Map(name, true)
-            case InternalDatatype.Singleton(name, _) => InternalDatatype.Singleton(name, true)
+            case InternalDatatype.List(name, _) => InternalDatatype.List(formatName(name), true)
+            case InternalDatatype.Map(name, _) => InternalDatatype.Map(formatName(name), true)
+            case InternalDatatype.Singleton(name, _) => InternalDatatype.Singleton(formatName(name), true)
           }
         }
 
         case Some(false) => {
           // User explicitly marked this optional
           dt match {
-            case InternalDatatype.List(name, _) => InternalDatatype.List(name, false)
-            case InternalDatatype.Map(name, _) => InternalDatatype.Map(name, false)
-            case InternalDatatype.Singleton(name, _) => InternalDatatype.Singleton(name, false)
+            case InternalDatatype.List(name, _) => InternalDatatype.List(formatName(name), false)
+            case InternalDatatype.Map(name, _) => InternalDatatype.Map(formatName(name), false)
+            case InternalDatatype.Singleton(name, _) => InternalDatatype.Singleton(formatName(name), false)
           }
         }
       }

--- a/core/src/test/scala/core/ServiceValidatorSpec.scala
+++ b/core/src/test/scala/core/ServiceValidatorSpec.scala
@@ -73,6 +73,25 @@ class ServiceValidatorSpec extends FunSpec with Matchers {
     validator.errors.mkString should be("user.foo has invalid type[foo]")
   }
 
+  it("types are lowercased in service definition") {
+    val json = """
+    {
+      "name": "Api Doc",
+      "models": {
+        "user": {
+          "fields": [
+            { "name": "id", "type": "UUID" }
+          ]
+        }
+      }
+    }
+    """
+    val validator = TestHelper.serviceValidatorFromApiJson(json)
+    validator.errors.mkString should be("")
+
+    validator.service.models.head.fields.head.`type` should be("uuid")
+  }
+
   it("base_url is optional") {
     val json = """
     {


### PR DESCRIPTION
 - Fixes #333
 - Enables user to specify UUID or uuid and both will work consistently
   using the primitive's actual name (e.g. uuid) in the service
   definition